### PR TITLE
Fix Config.set error log formatting

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -99,7 +99,7 @@ class Config:
             try:
                 self.config[str(key)] = value
             except Exception as e:
-                log("ERROR", "Config.set(): failed: {e}")
+                log("ERROR", f"Config.set(): failed: {e}")
 
 
 config = Config()


### PR DESCRIPTION
## Summary
- use f-string in Config.set error log

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a95e198d8c8333bcaea971348f3754