### PR TITLE
Clarify relay time adjustment comment

### DIFF
--- a/src/functions.py
+++ b/src/functions.py
@@ -56,7 +56,7 @@ async def adjust_relay_time_based_on_temp_category():
         multiplier = 1.0
 
         if temp_category == "HIGH":
-            # Shorter opening time for rapid temperature changes
+            # Longer opening time for rapid temperature changes
             multiplier = await config.get_float(
                 "temp_change_high_threshold_relay_time_multiplier", 1.5
             )


### PR DESCRIPTION
## Summary
- Correct comment in `adjust_relay_time_based_on_temp_category` to note longer opening time for rapid temperature changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a95ec683dc83338bfb2b8203d68c87